### PR TITLE
Use mindee settings when drawing canvas shape

### DIFF
--- a/src/helpers/colorUtils.js
+++ b/src/helpers/colorUtils.js
@@ -1,0 +1,23 @@
+// @flow
+export const hexaColorToRGBWithAndOpacity = function (
+  hexaColorString: string,
+  opacity: number
+) {
+  const hexaColorStringWithoutSharp = hexaColorString.replace(/#/, "").trim()
+  if (hexaColorStringWithoutSharp.length !== 6) {
+    console.error(
+      `"${hexaColorStringWithoutSharp}" is not a valid hex color only six-digit hex colors are allowed not ${hexaColorStringWithoutSharp.length}.`
+    )
+    return hexaColorString
+  }
+
+  const matchRgbFromHexadecimalString = hexaColorStringWithoutSharp.match(
+    /.{1,2}/g
+  )
+  const rgbColors = [
+    parseInt(matchRgbFromHexadecimalString[0], 16),
+    parseInt(matchRgbFromHexadecimalString[1], 16),
+    parseInt(matchRgbFromHexadecimalString[2], 16),
+  ]
+  return `rgba(${rgbColors.join(", ")}, ${opacity})`
+}

--- a/src/helpers/drawingUtils.js
+++ b/src/helpers/drawingUtils.js
@@ -5,6 +5,7 @@ import type { Shape } from "common/types"
 import { COLORS } from "./settings"
 import { zoomInto } from "./canvasUtils"
 import { type SettingsShape } from "./settings"
+import { hexaColorToRGBWithAndOpacity } from "./colorUtils"
 
 export const drawImage = (
   canvas: HTMLCanvasElement,
@@ -25,19 +26,20 @@ const drawPolyLines = (
   context: CanvasRenderingContext2D,
   points: Array<GeometryElement>,
   strokeStyle: any = COLORS.RED,
-  { strokes, fill, closePath, lineWidth }: any,
   {
-    isHighlighted = false,
-    lineWidth: _lineWidth = lineWidth,
-    color: _strokeStyle = strokeStyle,
-  }: any = {}
+    lineWidth,
+    fillOpacity,
+    closePath,
+    strokes,
+    fill,
+  }: $PropertyType<SettingsShape, "shapeOptions">
 ) => {
   context.save()
   context.beginPath()
-  const color = isHighlighted ? _strokeStyle : strokeStyle
+  const color = strokeStyle
   context.strokeStyle = color
-  context.lineWidth = isHighlighted ? _lineWidth : lineWidth
-  context.fillStyle = isHighlighted ? `${color}${50}` : `${color}${20}`
+  context.lineWidth = lineWidth
+  context.fillStyle = hexaColorToRGBWithAndOpacity(color, fillOpacity / 100)
   points.map((point) => context.lineTo(...point.toList()))
   closePath && context.closePath()
   strokes && context.stroke()
@@ -65,16 +67,14 @@ export const drawShapes = (
           selectedShape.featureName === shape.featureName &&
           selectedShape.index === shape.index) ||
         shape.isActive
-      drawPolyLines(
-        context,
-        scaledShape.points,
-        shape.color,
-        settings.shapeOptions,
-        {
-          isHighlighted,
-          ...shape.active,
-        }
-      )
+
+      const shapeOptions = isHighlighted
+        ? { ...settings.shapeOptions, ...settings.highlightedShapeOptions }
+        : settings.shapeOptions
+      drawPolyLines(context, scaledShape.points, shape.color, shapeOptions, {
+        isHighlighted,
+        ...shape.active,
+      })
     }
   })
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add new utility function to convert hexa decimal color to RGBA color

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[AnnotationViewer settings doesn't use global settings](https://github.com/publicMindee/react-mindee-js/issues/3)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
More customization over mindee Annotation Viewer using provided settings

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing has been made with storybook project (npm command test didn't work on run)
Change could affects existing integration since static color used will not change opacity

before:
shape `color = 20%` opacity and `hover = 50%` opacity

Now:
shape `color = settings.shapeOptions.fillOpacity` and `hover = settings.highlightedShapeOptions.fillOpacity || settings.shapeOptions.fillOpacity`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [ ] All new and existing tests passed.
