### PR TITLE
chg: :wrench: update prettier and eslint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,22 +1,46 @@
 {
-  "parser": "@typescript-eslint/parser", // Specifies the ESLint parser
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": 2020, // Allows for the parsing of modern ECMAScript features
-
-    "sourceType": "module" // Allows for the use of imports
+    "ecmaVersion": 2021,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "version": "detect"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "plugins": ["unused-imports", "@typescript-eslint"],
+  "globals": {
+    "cy": "readonly",
+    "Cypress": "readonly",
+    "InferenceDocument": "readonly",
+    "TrainingInterface": "readonly"
+  },
+  "env": {
+    "es2021": true,
+    "browser": true,
+    "node": true,
+    "jest": true,
+    "mocha": true
   },
   "extends": [
-    "plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-    "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
-
-    "plugin:prettier/recommended" // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended"
   ],
   "rules": {
-    "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/ban-ts-comment": "off",
-    "@typescript-eslint/no-namespace": "off",
-    "@typescript-eslint/no-non-null-assertion": "off"
-    // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-    // e.g. "@typescript-eslint/explicit-function-return-type": "off",
+    "no-unused-vars": "off",
+    "unused-imports/no-unused-vars": "error",
+    "unused-imports/no-unused-imports": "error",
+    "react/prop-types": "off",
+    "no-redeclare": "off",
+    "@typescript-eslint/ban-ts-comment": "warn",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-non-null-asserted-optional-chain": "warn",
+    "@typescript-eslint/no-empty-function": "warn"
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,9 +2,25 @@
   "printWidth": 80,
   "tabWidth": 2,
   "singleQuote": true,
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "semi": false,
-  "newline-before-return": true,
-  "no-duplicate-variable": [true, "check-parameters"],
-  "no-var-keyword": true
+  "importOrder": [
+    "^(react/(.*)$)|^(react$)",
+    "<THIRD_PARTY_MODULES>",
+    "",
+    "^@/common/(.*)$",
+    "",
+    "^@/components/(.*)$",
+    "",
+    "^@/utils/(.*)$",
+    "",
+    "^[./]"
+  ],
+  "importOrderSeparation": false,
+  "importOrderSortSpecifiers": true,
+  "importOrderBuiltinModulesToTop": true,
+  "importOrderParserPlugins": ["typescript", "jsx", "decorators-legacy"],
+  "importOrderMergeDuplicateImports": true,
+  "importOrderCombineTypeAndValueImports": true,
+  "plugins": ["@ianvs/prettier-plugin-sort-imports"]
 }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 import { addMatchImageSnapshotPlugin } from 'cypress-image-snapshot/plugin'
 import { defineConfig as defineViteConfig } from 'vite'
-
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -1,5 +1,5 @@
-import { mount } from 'cypress/react18'
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command'
+import { mount } from 'cypress/react18'
 
 addMatchImageSnapshotCommand()
 Cypress.Commands.add('mount', mount)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@cypress/react": "^7.0.3",
     "@cypress/vite-dev-server": "^2.0.7",
+    "@ianvs/prettier-plugin-sort-imports": "^4.0.2",
     "@types/cypress-image-snapshot": "^3.1.6",
     "@types/jest": "^27.0.1",
     "@types/node": "^20.3.3",
@@ -32,7 +33,7 @@
     "cypress-image-snapshot": "^4.0.1",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
-    "prettier": "^2.1.2",
+    "prettier": "^2.8.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ts-patch": "^1.4.3",
@@ -58,7 +59,9 @@
     "docs:prepare": "pnpm build && pnpm docs:install",
     "docs:update": "pnpm --dir ./docs add ../",
     "docs:build": "pnpm --dir ./docs build",
-    "docs:deploy": "pnpm --dir ./docs deploy"
+    "docs:deploy": "pnpm --dir ./docs deploy",
+    "prettier:check": "prettier --check ./src",
+    "prettier:write": "prettier --write ./src"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,15 @@
     "@types/node": "^20.3.3",
     "@types/react": "^17.0.19",
     "@types/uuid": "^8.3.1",
-    "@typescript-eslint/eslint-plugin": "^4.7.0",
-    "@typescript-eslint/parser": "^4.7.0",
+    "@typescript-eslint/eslint-plugin": "^5.61.0",
+    "@typescript-eslint/parser": "^5.61.0",
     "@vitejs/plugin-react": "^4.0.1",
     "cypress": "^12.16.0",
     "cypress-image-snapshot": "^4.0.1",
+    "eslint": "^8.44.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "prettier": "^2.8.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -61,7 +63,8 @@
     "docs:build": "pnpm --dir ./docs build",
     "docs:deploy": "pnpm --dir ./docs deploy",
     "prettier:check": "prettier --check ./src",
-    "prettier:write": "prettier --write ./src"
+    "prettier:write": "prettier --write ./src",
+    "lint": "tsc --noemit && eslint --fix --ext .ts,.tsx . && prettier --write ./src"
   },
   "keywords": [
     "react",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ devDependencies:
   '@cypress/vite-dev-server':
     specifier: ^2.0.7
     version: 2.0.8(vite@4.3.9)
+  '@ianvs/prettier-plugin-sort-imports':
+    specifier: ^4.0.2
+    version: 4.0.2(prettier@2.8.8)
   '@types/cypress-image-snapshot':
     specifier: ^3.1.6
     version: 3.1.6
@@ -57,10 +60,10 @@ devDependencies:
     version: 6.15.0(eslint@7.32.0)
   eslint-plugin-prettier:
     specifier: ^3.1.4
-    version: 3.4.1(eslint-config-prettier@6.15.0)(eslint@7.32.0)(prettier@2.3.2)
+    version: 3.4.1(eslint-config-prettier@6.15.0)(eslint@7.32.0)(prettier@2.8.8)
   prettier:
-    specifier: ^2.1.2
-    version: 2.3.2
+    specifier: ^2.8.8
+    version: 2.8.8
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -129,7 +132,7 @@ packages:
       '@babel/traverse': 7.22.5
       '@babel/types': 7.22.5
       convert-source-map: 1.8.0
-      debug: 4.3.2
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -741,6 +744,26 @@ packages:
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
+
+  /@ianvs/prettier-plugin-sort-imports@4.0.2(prettier@2.8.8):
+    resolution: {integrity: sha512-VnsTzyb9aSWpc3v6HvZKD6eolZRvofIYjhda+6IbW1GYwr2byWqK0KhLPbYNkit9MAgShad5bhZ1hgBn867A1A==}
+    peerDependencies:
+      '@vue/compiler-sfc': '>=3.0.0'
+      prettier: 2.x
+    peerDependenciesMeta:
+      '@vue/compiler-sfc':
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/generator': 7.22.5
+      '@babel/parser': 7.22.5
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
+      prettier: 2.8.8
+      semver: 7.5.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@istanbuljs/load-nyc-config@1.1.0:
@@ -2498,7 +2521,7 @@ packages:
       get-stdin: 6.0.0
     dev: true
 
-  /eslint-plugin-prettier@3.4.1(eslint-config-prettier@6.15.0)(eslint@7.32.0)(prettier@2.3.2):
+  /eslint-plugin-prettier@3.4.1(eslint-config-prettier@6.15.0)(eslint@7.32.0)(prettier@2.8.8):
     resolution: {integrity: sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -2511,7 +2534,7 @@ packages:
     dependencies:
       eslint: 7.32.0
       eslint-config-prettier: 6.15.0(eslint@7.32.0)
-      prettier: 2.3.2
+      prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -4838,8 +4861,8 @@ packages:
       fast-diff: 1.2.0
     dev: true
 
-  /prettier@2.3.2:
-    resolution: {integrity: sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==}
+  /prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,11 +41,11 @@ devDependencies:
     specifier: ^8.3.1
     version: 8.3.1
   '@typescript-eslint/eslint-plugin':
-    specifier: ^4.7.0
-    version: 4.29.3(@typescript-eslint/parser@4.29.3)(eslint@7.32.0)(typescript@4.9.5)
+    specifier: ^5.61.0
+    version: 5.61.0(@typescript-eslint/parser@5.61.0)(eslint@8.44.0)(typescript@4.9.5)
   '@typescript-eslint/parser':
-    specifier: ^4.7.0
-    version: 4.29.3(eslint@7.32.0)(typescript@4.9.5)
+    specifier: ^5.61.0
+    version: 5.61.0(eslint@8.44.0)(typescript@4.9.5)
   '@vitejs/plugin-react':
     specifier: ^4.0.1
     version: 4.0.1(vite@4.3.9)
@@ -55,12 +55,18 @@ devDependencies:
   cypress-image-snapshot:
     specifier: ^4.0.1
     version: 4.0.1(cypress@12.16.0)(jest@26.6.3)
+  eslint:
+    specifier: ^8.44.0
+    version: 8.44.0
   eslint-config-prettier:
     specifier: ^6.15.0
-    version: 6.15.0(eslint@7.32.0)
+    version: 6.15.0(eslint@8.44.0)
   eslint-plugin-prettier:
     specifier: ^3.1.4
-    version: 3.4.1(eslint-config-prettier@6.15.0)(eslint@7.32.0)(prettier@2.8.8)
+    version: 3.4.1(eslint-config-prettier@6.15.0)(eslint@8.44.0)(prettier@2.8.8)
+  eslint-plugin-unused-imports:
+    specifier: ^2.0.0
+    version: 2.0.0(@typescript-eslint/eslint-plugin@5.61.0)(eslint@8.44.0)
   prettier:
     specifier: ^2.8.8
     version: 2.8.8
@@ -91,18 +97,17 @@ devDependencies:
 
 packages:
 
+  /@aashutoshrathi/word-wrap@1.2.6:
+    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
-    dev: true
-
-  /@babel/code-frame@7.12.11:
-    resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
-    dependencies:
-      '@babel/highlight': 7.22.5
     dev: true
 
   /@babel/code-frame@7.22.5:
@@ -714,32 +719,57 @@ packages:
     dev: true
     optional: true
 
-  /@eslint/eslintrc@0.4.3:
-    resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.44.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.44.0
+      eslint-visitor-keys: 3.4.1
+    dev: true
+
+  /@eslint-community/regexpp@4.5.1:
+    resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
+  /@eslint/eslintrc@2.1.0:
+    resolution: {integrity: sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4(supports-color@8.1.1)
-      espree: 7.3.1
+      espree: 9.6.0
       globals: 13.20.0
-      ignore: 4.0.6
+      ignore: 5.2.4
       import-fresh: 3.3.0
-      js-yaml: 3.14.1
-      minimatch: 3.0.4
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@humanwhocodes/config-array@0.5.0:
-    resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
+  /@eslint/js@8.44.0:
+    resolution: {integrity: sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@humanwhocodes/config-array@0.11.10:
+    resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.3.4(supports-color@8.1.1)
-      minimatch: 3.0.4
+      minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@humanwhocodes/module-importer@1.0.1:
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
     dev: true
 
   /@humanwhocodes/object-schema@1.2.1:
@@ -821,7 +851,7 @@ packages:
       jest-util: 26.6.2
       jest-validate: 26.6.2
       jest-watcher: 26.6.2
-      micromatch: 4.0.2
+      micromatch: 4.0.5
       p-each-series: 2.2.0
       rimraf: 3.0.2
       slash: 3.0.0
@@ -949,7 +979,7 @@ packages:
       jest-haste-map: 26.6.2
       jest-regex-util: 26.0.0
       jest-util: 26.6.2
-      micromatch: 4.0.2
+      micromatch: 4.0.5
       pirates: 4.0.6
       slash: 3.0.0
       source-map: 0.6.1
@@ -1057,24 +1087,24 @@ packages:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
     dev: true
 
-  /@nodelib/fs.scandir@2.1.4:
-    resolution: {integrity: sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==}
+  /@nodelib/fs.scandir@2.1.5:
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
     dependencies:
-      '@nodelib/fs.stat': 2.0.4
+      '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
     dev: true
 
-  /@nodelib/fs.stat@2.0.4:
-    resolution: {integrity: sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==}
+  /@nodelib/fs.stat@2.0.5:
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
     dev: true
 
-  /@nodelib/fs.walk@1.2.6:
-    resolution: {integrity: sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==}
+  /@nodelib/fs.walk@1.2.8:
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
     dependencies:
-      '@nodelib/fs.scandir': 2.1.4
+      '@nodelib/fs.scandir': 2.1.5
       fastq: 1.10.1
     dev: true
 
@@ -1254,6 +1284,10 @@ packages:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
     dev: true
 
+  /@types/semver@7.5.0:
+    resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+    dev: true
+
   /@types/sinonjs__fake-timers@8.1.1:
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
     dev: true
@@ -1294,109 +1328,134 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin@4.29.3(@typescript-eslint/parser@4.29.3)(eslint@7.32.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-tBgfA3K/3TsZY46ROGvoRxQr1wBkclbVqRQep97MjVHJzcRBURRY3sNFqLk0/Xr//BY5hM9H2p/kp+6qim85SA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/eslint-plugin@5.61.0(@typescript-eslint/parser@5.61.0)(eslint@8.44.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-A5l/eUAug103qtkwccSCxn8ZRwT+7RXWkFECdA4Cvl1dOlDUgTpAOfSEElZn2uSUxhdDpnCdetrf0jvU4qrL+g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.29.3(eslint@7.32.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 4.29.3(eslint@7.32.0)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 4.29.3
-      debug: 4.3.2
-      eslint: 7.32.0
-      functional-red-black-tree: 1.0.1
-      regexpp: 3.1.0
-      semver: 7.3.5
+      '@eslint-community/regexpp': 4.5.1
+      '@typescript-eslint/parser': 5.61.0(eslint@8.44.0)(typescript@4.9.5)
+      '@typescript-eslint/scope-manager': 5.61.0
+      '@typescript-eslint/type-utils': 5.61.0(eslint@8.44.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.61.0(eslint@8.44.0)(typescript@4.9.5)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.44.0
+      graphemer: 1.4.0
+      ignore: 5.2.4
+      natural-compare-lite: 1.4.0
+      semver: 7.5.3
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@4.29.3(eslint@7.32.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-ffIvbytTVWz+3keg+Sy94FG1QeOvmV9dP2YSdLFHw/ieLXWCa3U1TYu8IRCOpMv2/SPS8XqhM1+ou1YHsdzKrg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/parser@5.61.0(eslint@8.44.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-yGr4Sgyh8uO6fSi9hw3jAFXNBHbCtKKFMdX2IkT3ZqpKmtAq3lHS4ixB/COFuAIJpwl9/AqF7j72ZDWYKmIfvg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.61.0
+      '@typescript-eslint/types': 5.61.0
+      '@typescript-eslint/typescript-estree': 5.61.0(typescript@4.9.5)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.44.0
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/scope-manager@5.61.0:
+    resolution: {integrity: sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.61.0
+      '@typescript-eslint/visitor-keys': 5.61.0
+    dev: true
+
+  /@typescript-eslint/type-utils@5.61.0(eslint@8.44.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-kk8u//r+oVK2Aj3ph/26XdH0pbAkC2RiSjUYhKD+PExemG4XSjpGFeyZ/QM8lBOa7O8aGOU+/yEbMJgQv/DnCg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
+      '@typescript-eslint/typescript-estree': 5.61.0(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.61.0(eslint@8.44.0)(typescript@4.9.5)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.44.0
+      tsutils: 3.21.0(typescript@4.9.5)
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/types@5.61.0:
+    resolution: {integrity: sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree@5.61.0(typescript@4.9.5):
+    resolution: {integrity: sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.61.0
+      '@typescript-eslint/visitor-keys': 5.61.0
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.3
+      tsutils: 3.21.0(typescript@4.9.5)
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils@5.61.0(eslint@8.44.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
       '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 4.29.3
-      '@typescript-eslint/types': 4.29.3
-      '@typescript-eslint/typescript-estree': 4.29.3(typescript@4.9.5)
-      eslint: 7.32.0
+      '@types/semver': 7.5.0
+      '@typescript-eslint/scope-manager': 5.61.0
+      '@typescript-eslint/types': 5.61.0
+      '@typescript-eslint/typescript-estree': 5.61.0(typescript@4.9.5)
+      eslint: 8.44.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@7.32.0)
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser@4.29.3(eslint@7.32.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-jrHOV5g2u8ROghmspKoW7pN8T/qUzk0+DITun0MELptvngtMrwUJ1tv5zMI04CYVEUsSrN4jV7AKSv+I0y0EfQ==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  /@typescript-eslint/visitor-keys@5.61.0:
+    resolution: {integrity: sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/scope-manager': 4.29.3
-      '@typescript-eslint/types': 4.29.3
-      '@typescript-eslint/typescript-estree': 4.29.3(typescript@4.9.5)
-      debug: 4.3.2
-      eslint: 7.32.0
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/scope-manager@4.29.3:
-    resolution: {integrity: sha512-x+w8BLXO7iWPkG5mEy9bA1iFRnk36p/goVlYobVWHyDw69YmaH9q6eA+Fgl7kYHmFvWlebUTUfhtIg4zbbl8PA==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dependencies:
-      '@typescript-eslint/types': 4.29.3
-      '@typescript-eslint/visitor-keys': 4.29.3
-    dev: true
-
-  /@typescript-eslint/types@4.29.3:
-    resolution: {integrity: sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dev: true
-
-  /@typescript-eslint/typescript-estree@4.29.3(typescript@4.9.5):
-    resolution: {integrity: sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 4.29.3
-      '@typescript-eslint/visitor-keys': 4.29.3
-      debug: 4.3.2
-      globby: 11.0.4
-      is-glob: 4.0.1
-      semver: 7.3.5
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/visitor-keys@4.29.3:
-    resolution: {integrity: sha512-MGGfJvXT4asUTeVs0Q2m+sY63UsfnA+C/FDgBKV3itLBmM9H0u+URcneePtkd0at1YELmZK6HSolCqM4Fzs6yA==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dependencies:
-      '@typescript-eslint/types': 4.29.3
-      eslint-visitor-keys: 2.0.0
+      '@typescript-eslint/types': 5.61.0
+      eslint-visitor-keys: 3.4.1
     dev: true
 
   /@vitejs/plugin-react@4.0.1(vite@4.3.9):
@@ -1497,12 +1556,12 @@ packages:
       acorn-walk: 7.2.0
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@7.4.1):
+  /acorn-jsx@5.3.2(acorn@8.9.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 7.4.1
+      acorn: 8.9.0
     dev: true
 
   /acorn-walk@7.2.0:
@@ -1545,15 +1604,6 @@ packages:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-    dev: true
-
-  /ajv@8.12.0:
-    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
       uri-js: 4.4.1
     dev: true
 
@@ -1640,6 +1690,10 @@ packages:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
       sprintf-js: 1.0.3
+    dev: true
+
+  /argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
 
   /arr-diff@4.0.0:
@@ -2511,17 +2565,17 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-prettier@6.15.0(eslint@7.32.0):
+  /eslint-config-prettier@6.15.0(eslint@8.44.0):
     resolution: {integrity: sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==}
     hasBin: true
     peerDependencies:
       eslint: '>=3.14.1'
     dependencies:
-      eslint: 7.32.0
+      eslint: 8.44.0
       get-stdin: 6.0.0
     dev: true
 
-  /eslint-plugin-prettier@3.4.1(eslint-config-prettier@6.15.0)(eslint@7.32.0)(prettier@2.8.8):
+  /eslint-plugin-prettier@3.4.1(eslint-config-prettier@6.15.0)(eslint@8.44.0)(prettier@2.8.8):
     resolution: {integrity: sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -2532,10 +2586,30 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      eslint: 7.32.0
-      eslint-config-prettier: 6.15.0(eslint@7.32.0)
+      eslint: 8.44.0
+      eslint-config-prettier: 6.15.0(eslint@8.44.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
+    dev: true
+
+  /eslint-plugin-unused-imports@2.0.0(@typescript-eslint/eslint-plugin@5.61.0)(eslint@8.44.0):
+    resolution: {integrity: sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.61.0(@typescript-eslint/parser@5.61.0)(eslint@8.44.0)(typescript@4.9.5)
+      eslint: 8.44.0
+      eslint-rule-composer: 0.3.0
+    dev: true
+
+  /eslint-rule-composer@0.3.0:
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
+    engines: {node: '>=4.0.0'}
     dev: true
 
   /eslint-scope@5.1.1:
@@ -2546,89 +2620,74 @@ packages:
       estraverse: 4.3.0
     dev: true
 
-  /eslint-utils@2.1.0:
-    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
-    engines: {node: '>=6'}
+  /eslint-scope@7.2.0:
+    resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      eslint-visitor-keys: 1.3.0
+      esrecurse: 4.3.0
+      estraverse: 5.2.0
     dev: true
 
-  /eslint-utils@3.0.0(eslint@7.32.0):
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 7.32.0
-      eslint-visitor-keys: 2.0.0
+  /eslint-visitor-keys@3.4.1:
+    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint-visitor-keys@1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /eslint-visitor-keys@2.0.0:
-    resolution: {integrity: sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /eslint@7.32.0:
-    resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /eslint@8.44.0:
+    resolution: {integrity: sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.3
-      '@humanwhocodes/config-array': 0.5.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
+      '@eslint-community/regexpp': 4.5.1
+      '@eslint/eslintrc': 2.1.0
+      '@eslint/js': 8.44.0
+      '@humanwhocodes/config-array': 0.11.10
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
       debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
-      enquirer: 2.3.6
       escape-string-regexp: 4.0.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-      eslint-visitor-keys: 2.0.0
-      espree: 7.3.1
+      eslint-scope: 7.2.0
+      eslint-visitor-keys: 3.4.1
+      espree: 9.6.0
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.2
+      find-up: 5.0.0
+      glob-parent: 6.0.2
       globals: 13.20.0
-      ignore: 4.0.6
+      graphemer: 1.4.0
+      ignore: 5.2.4
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.1
-      js-yaml: 3.14.1
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       natural-compare: 1.4.0
-      optionator: 0.9.1
-      progress: 2.0.3
-      regexpp: 3.1.0
-      semver: 7.5.3
+      optionator: 0.9.3
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
-      table: 6.8.1
       text-table: 0.2.0
-      v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /espree@7.3.1:
-    resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /espree@9.6.0:
+    resolution: {integrity: sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 7.4.1
-      acorn-jsx: 5.3.2(acorn@7.4.1)
-      eslint-visitor-keys: 1.3.0
+      acorn: 8.9.0
+      acorn-jsx: 5.3.2(acorn@8.9.0)
+      eslint-visitor-keys: 3.4.1
     dev: true
 
   /esprima@4.0.1:
@@ -2812,16 +2871,15 @@ packages:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
     dev: true
 
-  /fast-glob@3.2.5:
-    resolution: {integrity: sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==}
-    engines: {node: '>=8'}
+  /fast-glob@3.3.0:
+    resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==}
+    engines: {node: '>=8.6.0'}
     dependencies:
-      '@nodelib/fs.stat': 2.0.4
-      '@nodelib/fs.walk': 1.2.6
-      glob-parent: 5.1.1
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.2
-      picomatch: 2.3.0
+      micromatch: 4.0.5
     dev: true
 
   /fast-json-stable-stringify@2.1.0:
@@ -2893,6 +2951,14 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       locate-path: 5.0.0
+      path-exists: 4.0.0
+    dev: true
+
+  /find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+    dependencies:
+      locate-path: 6.0.0
       path-exists: 4.0.0
     dev: true
 
@@ -2977,10 +3043,6 @@ packages:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
     dev: true
 
-  /functional-red-black-tree@1.0.1:
-    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
-    dev: true
-
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -3051,18 +3113,18 @@ packages:
       assert-plus: 1.0.0
     dev: true
 
-  /glob-parent@5.1.1:
-    resolution: {integrity: sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==}
-    engines: {node: '>= 6'}
-    dependencies:
-      is-glob: 4.0.1
-    dev: true
-
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
     dependencies:
-      is-glob: 4.0.1
+      is-glob: 4.0.3
+    dev: true
+
+  /glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      is-glob: 4.0.3
     dev: true
 
   /glob@7.1.7:
@@ -3071,7 +3133,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -3104,14 +3166,14 @@ packages:
       type-fest: 0.20.2
     dev: true
 
-  /globby@11.0.4:
-    resolution: {integrity: sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==}
+  /globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.5
-      ignore: 5.1.8
+      fast-glob: 3.3.0
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -3126,6 +3188,10 @@ packages:
 
   /graceful-fs@4.2.8:
     resolution: {integrity: sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==}
+    dev: true
+
+  /graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
   /growly@1.3.0:
@@ -3264,13 +3330,8 @@ packages:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: true
 
-  /ignore@4.0.6:
-    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
-    engines: {node: '>= 4'}
-    dev: true
-
-  /ignore@5.1.8:
-    resolution: {integrity: sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==}
+  /ignore@5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -3447,6 +3508,13 @@ packages:
 
   /is-glob@4.0.1:
     resolution: {integrity: sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+    dev: true
+
+  /is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
@@ -3670,7 +3738,7 @@ packages:
       jest-resolve: 26.6.2
       jest-util: 26.6.2
       jest-validate: 26.6.2
-      micromatch: 4.0.2
+      micromatch: 4.0.5
       pretty-format: 26.6.2
     transitivePeerDependencies:
       - bufferutil
@@ -3771,7 +3839,7 @@ packages:
       jest-serializer: 26.6.2
       jest-util: 26.6.2
       jest-worker: 26.6.2
-      micromatch: 4.0.2
+      micromatch: 4.0.5
       sane: 4.1.0
       walker: 1.0.8
     optionalDependencies:
@@ -3855,7 +3923,7 @@ packages:
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.8
-      micromatch: 4.0.2
+      micromatch: 4.0.5
       pretty-format: 26.6.2
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -4024,7 +4092,7 @@ packages:
       chalk: 4.1.2
       graceful-fs: 4.2.8
       is-ci: 2.0.0
-      micromatch: 4.0.2
+      micromatch: 4.0.5
     dev: true
 
   /jest-validate@26.6.2:
@@ -4093,6 +4161,13 @@ packages:
       esprima: 4.0.1
     dev: true
 
+  /js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+    dev: true
+
   /jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
     dev: true
@@ -4151,10 +4226,6 @@ packages:
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-    dev: true
-
-  /json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
     dev: true
 
   /json-schema@0.4.0:
@@ -4297,6 +4368,13 @@ packages:
       p-locate: 4.1.0
     dev: true
 
+  /locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-locate: 5.0.0
+    dev: true
+
   /lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     dev: true
@@ -4311,10 +4389,6 @@ packages:
 
   /lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
-    dev: true
-
-  /lodash.truncate@4.4.2:
-    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
     dev: true
 
   /lodash@4.17.21:
@@ -4414,12 +4488,12 @@ packages:
       - supports-color
     dev: true
 
-  /micromatch@4.0.2:
-    resolution: {integrity: sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==}
-    engines: {node: '>=8'}
+  /micromatch@4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
     dependencies:
       braces: 3.0.2
-      picomatch: 2.3.0
+      picomatch: 2.3.1
     dev: true
 
   /mime-db@1.49.0:
@@ -4441,6 +4515,12 @@ packages:
 
   /minimatch@3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
     dev: true
@@ -4514,6 +4594,10 @@ packages:
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /natural-compare-lite@1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
 
   /natural-compare@1.4.0:
@@ -4636,16 +4720,16 @@ packages:
       word-wrap: 1.2.3
     dev: true
 
-  /optionator@0.9.1:
-    resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
+  /optionator@0.9.3:
+    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
     dependencies:
+      '@aashutoshrathi/word-wrap': 1.2.6
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
-      word-wrap: 1.2.3
     dev: true
 
   /ospath@1.2.2:
@@ -4669,6 +4753,13 @@ packages:
       p-try: 2.2.0
     dev: true
 
+  /p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      yocto-queue: 0.1.0
+    dev: true
+
   /p-locate@3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
     engines: {node: '>=6'}
@@ -4681,6 +4772,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
+    dev: true
+
+  /p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-limit: 3.1.0
     dev: true
 
   /p-map@4.0.0:
@@ -4769,11 +4867,6 @@ packages:
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-    dev: true
-
-  /picomatch@2.3.0:
-    resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==}
-    engines: {node: '>=8.6'}
     dev: true
 
   /picomatch@2.3.1:
@@ -4892,11 +4985,6 @@ packages:
       react-is: 17.0.2
     dev: true
 
-  /progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
-    dev: true
-
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -5000,11 +5088,6 @@ packages:
       safe-regex: 1.1.0
     dev: true
 
-  /regexpp@3.1.0:
-    resolution: {integrity: sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==}
-    engines: {node: '>=8'}
-    dev: true
-
   /remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
     dev: true
@@ -5027,11 +5110,6 @@ packages:
 
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -5490,7 +5568,7 @@ packages:
     resolution: {integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==}
     engines: {node: '>=8'}
     dependencies:
-      ansi-regex: 5.0.0
+      ansi-regex: 5.0.1
     dev: true
 
   /strip-ansi@6.0.1:
@@ -5563,17 +5641,6 @@ packages:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
 
-  /table@6.8.1:
-    resolution: {integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      ajv: 8.12.0
-      lodash.truncate: 4.4.2
-      slice-ansi: 4.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-    dev: true
-
   /term-img@4.1.0:
     resolution: {integrity: sha512-DFpBhaF5j+2f7kheKFc1ajsAUUDGOaNPpKPtiIMxlbfud6mvfFZuWGnTRpaujUa5J7yl6cIw/h6nyr4mSsENPg==}
     engines: {node: '>=8'}
@@ -5596,7 +5663,7 @@ packages:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.1.7
-      minimatch: 3.0.4
+      minimatch: 3.1.2
     dev: true
 
   /text-table@0.2.0:
@@ -5882,10 +5949,6 @@ packages:
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
-
-  /v8-compile-cache@2.3.0:
-    resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
-    dev: true
 
   /v8-to-istanbul@7.1.2:
     resolution: {integrity: sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==}
@@ -6185,6 +6248,11 @@ packages:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+    dev: true
+
+  /yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
     dev: true
 
   /z-schema@5.0.5:

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,4 +1,5 @@
 import { Line } from 'konva/lib/shapes/Line'
+
 import { AnnotationData } from '..'
 
 export const DEFAULT_STYLE = {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,8 +1,9 @@
-import { Stage } from '..'
+import { CSSProperties } from 'react'
 import Konva from 'konva'
 import { Line, LineConfig } from 'konva/lib/shapes/Line'
 import { RectConfig } from 'konva/lib/shapes/Rect'
-import { CSSProperties } from 'react'
+
+import { Stage } from '..'
 
 export type AnnotationShape<T = any> = T & {
   id: string

--- a/src/components/AnnotationLens.spec.tsx
+++ b/src/components/AnnotationLens.spec.tsx
@@ -1,11 +1,11 @@
-import { dummyShapes } from 'cypress/assets/shapes'
 import React, { useState } from 'react'
-
-import dummyImage from 'cypress/assets/demo.jpg'
 import anotherDummyImage from 'cypress/assets/another-demo.jpg'
+import dummyImage from 'cypress/assets/demo.jpg'
+import { dummyShapes } from 'cypress/assets/shapes'
+
+import { AnnotationData } from '@/common/types'
 
 import AnnotationLens from './AnnotationLens'
-import { AnnotationData } from '@/common/types'
 
 const containerHeight = 600
 const containerWidth = 600
@@ -107,7 +107,7 @@ describe('AnnotationLens', () => {
         containerHeight={containerHeight}
         containerWidth={containerWidth}
         id={componentId}
-      />
+      />,
     ).then(() => {
       cy.wait(500)
       cy.pause()
@@ -124,7 +124,7 @@ describe('AnnotationLens', () => {
         .click()
         .then(() => {
           cy.get(`#${componentId}`).matchImageSnapshot(
-            componentId + '.pointer-move.1'
+            componentId + '.pointer-move.1',
           )
         })
 
@@ -132,14 +132,14 @@ describe('AnnotationLens', () => {
         .click()
         .then(() => {
           cy.get(`#${componentId}`).matchImageSnapshot(
-            componentId + '.pointer-move.2'
+            componentId + '.pointer-move.2',
           )
         })
       cy.get('[data-cy="move-pointer"]')
         .click()
         .then(() => {
           cy.get(`#${componentId}`).matchImageSnapshot(
-            componentId + '.pointer-move.3'
+            componentId + '.pointer-move.3',
           )
         })
     })
@@ -151,7 +151,7 @@ describe('AnnotationLens', () => {
         id={componentId}
         containerHeight={containerHeight}
         containerWidth={containerWidth}
-      />
+      />,
     ).then(() => {
       cy.get('[data-cy="same-data"]').click()
       cy.wait(400)
@@ -159,17 +159,17 @@ describe('AnnotationLens', () => {
       cy.get('[data-cy="different-image"]').click()
       cy.wait(400)
       cy.get(`#${componentId}`).matchImageSnapshot(
-        'annotationLens.different-image'
+        'annotationLens.different-image',
       )
       cy.get('[data-cy="different-shapes"]').click()
       cy.wait(400)
       cy.get(`#${componentId}`).matchImageSnapshot(
-        'annotationLens.different-shapes'
+        'annotationLens.different-shapes',
       )
       cy.get('[data-cy="different-orientation"]').click()
       cy.wait(400)
       cy.get(`#${componentId}`).matchImageSnapshot(
-        'annotationLens.different-orientation'
+        'annotationLens.different-orientation',
       )
     })
   })

--- a/src/components/AnnotationLens.tsx
+++ b/src/components/AnnotationLens.tsx
@@ -3,25 +3,24 @@ import Konva from 'konva'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
-  KONVA_REFS,
-  DEFAULT_STYLE,
-  DEFAULT_POINTER_POSITION,
-  DEFAULT_LENS_ZOOM_LEVEL,
-  DEFAULT_DATA,
   DEFAULT_ANNOTATION_LENS_OPTIONS,
+  DEFAULT_DATA,
+  DEFAULT_LENS_ZOOM_LEVEL,
+  DEFAULT_POINTER_POSITION,
+  DEFAULT_STYLE,
+  KONVA_REFS,
 } from '@/common/constants'
-
 import {
+  AnnotationLensProps,
   ImageBoundingBox,
   ImageData,
-  AnnotationLensProps,
 } from '@/common/types'
 
 import { mapShapesToPolygons } from '@/utils/canvas'
-import { rotateImage } from '@/utils/orientation'
-import { handleLensZoom } from '@/utils/zoom'
 import { handleResizeImage } from '@/utils/image'
 import { clearLayers } from '@/utils/layer'
+import { rotateImage } from '@/utils/orientation'
+import { handleLensZoom } from '@/utils/zoom'
 
 export default function AnnotationLens({
   id: containerId = uuidv4(),
@@ -57,7 +56,7 @@ export default function AnnotationLens({
     getStage?.(stageObject.current)
     stageObject.current.add(
       layersObject.current.image,
-      layersObject.current.shapes
+      layersObject.current.shapes,
     )
     layersObject.current.image.add(imageDataObject.current.shape)
   }, [])
@@ -67,7 +66,7 @@ export default function AnnotationLens({
       stageObject.current,
       imageBoundingBoxObject.current,
       pointerPosition,
-      zoomLevel
+      zoomLevel,
     )
   }
 
@@ -122,7 +121,7 @@ export default function AnnotationLens({
       annotationData.current.shapes,
       false,
       imageBoundingBoxObject.current,
-      options
+      options,
     )
 
     layersObject.current.shapes.batchDraw()
@@ -132,7 +131,7 @@ export default function AnnotationLens({
     const imageBoundingBox = handleResizeImage(
       stageObject.current,
       containerRef.current,
-      imageDataObject.current
+      imageDataObject.current,
     )
     if (imageBoundingBox) {
       imageBoundingBoxObject.current = imageBoundingBox

--- a/src/components/AnnotationViewer.spec.tsx
+++ b/src/components/AnnotationViewer.spec.tsx
@@ -1,12 +1,11 @@
-import React from 'react'
-
+import React, { useState } from 'react'
 import anotherDummyImage from 'cypress/assets/another-demo.jpg'
 import dummyImage from 'cypress/assets/demo.jpg'
-import { dummyShapes } from '../../cypress/assets/shapes'
-import { useState } from 'react'
 
-import AnnotationViewer from './AnnotationViewer'
 import { AnnotationData, AnnotationShape } from '@/common/types'
+
+import { dummyShapes } from '../../cypress/assets/shapes'
+import AnnotationViewer from './AnnotationViewer'
 
 const containerHeight = 800
 const containerWidth = 700
@@ -86,7 +85,7 @@ describe('AnnotationViewer', () => {
         id="annotationViewer"
         data={{ image: dummyImage, shapes: dummyShapes }}
         style={{ height: containerHeight, width: containerWidth }}
-      />
+      />,
     )
     cy.wait(1000)
     cy.get('canvas')
@@ -106,7 +105,7 @@ describe('AnnotationViewer', () => {
         id="annotationViewer"
         data={{ image: dummyImage, shapes: dummyShapes }}
         style={{ height: containerHeight, width: containerWidth }}
-      />
+      />,
     )
     cy.wait(1000)
     cy.get('#annotationViewer')
@@ -152,7 +151,7 @@ describe('AnnotationViewer', () => {
       />,
       {
         log: true,
-      }
+      },
     )
     cy.wait(1000)
     cy.get('#annotationViewer')
@@ -214,7 +213,7 @@ describe('AnnotationViewer', () => {
         data={{ image: dummyImage, shapes: dummyShapes }}
         style={{ height: containerHeight, width: containerWidth }}
         onShapeMultiSelect={events.onShapeMultiSelect}
-      />
+      />,
     ).then(() => {
       cy.pause()
       cy.get('#annotationViewer')
@@ -229,7 +228,7 @@ describe('AnnotationViewer', () => {
         .then(() => {
           cy.wait(200)
           expect(events.onShapeMultiSelect).to.be.calledOnceWithExactly(
-            dummyShapes.slice(0, 2)
+            dummyShapes.slice(0, 2),
           )
         })
     })
@@ -245,7 +244,7 @@ describe('AnnotationViewer', () => {
         id="annotationViewer"
         data={{ image: dummyImage, shapes: dummyShapes }}
         style={{ height: containerHeight, width: containerWidth }}
-      />
+      />,
     ).then(() => {
       cy.get('#annotationViewer').matchImageSnapshot('custom-options')
     })
@@ -257,7 +256,7 @@ describe('AnnotationViewer', () => {
         id="annotationViewer"
         containerHeight={containerHeight}
         containerWidth={containerWidth}
-      />
+      />,
     ).then(() => {
       cy.get('[data-cy="same-data"]').click()
       cy.wait(400)

--- a/src/components/AnnotationViewer.tsx
+++ b/src/components/AnnotationViewer.tsx
@@ -80,8 +80,8 @@ export default function AnnotationViewer({
       stageObject.current &&
       imageBoundingBoxObject.current
     ) {
-      let stageX = stageObject.current.x()
-      let stageY = stageObject.current.y()
+      const stageX = stageObject.current.x()
+      const stageY = stageObject.current.y()
       const zoomScale = stageObject.current.getAttr('zoomScale')
       const newPosition = {
         x: stageX + customStagePosition.x * zoomScale,

--- a/src/components/AnnotationViewer.tsx
+++ b/src/components/AnnotationViewer.tsx
@@ -1,35 +1,32 @@
-import { KonvaEventObject } from 'konva/lib/Node'
-import React from 'react'
-import { useEffect, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import Konva from 'konva'
+import { KonvaEventObject } from 'konva/lib/Node'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
-  onSelectionStart,
-  onSelectionMove,
-  onSelectionEnd,
-  createSelectionRect,
-} from '@/utils/selection'
-
+  DEFAULT_ANNOTATION_VIEWER_OPTIONS,
+  DEFAULT_DATA,
+  DEFAULT_STYLE,
+  KONVA_REFS,
+} from '@/common/constants'
 import {
   AnnotationViewerProps,
   ImageBoundingBox,
   ImageData,
 } from '@/common/types'
 
-import {
-  KONVA_REFS,
-  DEFAULT_STYLE,
-  DEFAULT_DATA,
-  DEFAULT_ANNOTATION_VIEWER_OPTIONS,
-} from '@/common/constants'
-
 import { getMousePosition, mapShapesToPolygons } from '@/utils/canvas'
-import { rotateImage } from '@/utils/orientation'
-import { handleStageZoom, handleZoomScale } from '@/utils/zoom'
-import useMultiSelection from '@/utils/useMultiSelection'
 import { handleResizeImage, setStageBasedImagePosition } from '@/utils/image'
 import { clearLayers } from '@/utils/layer'
+import { rotateImage } from '@/utils/orientation'
+import {
+  createSelectionRect,
+  onSelectionEnd,
+  onSelectionMove,
+  onSelectionStart,
+} from '@/utils/selection'
+import useMultiSelection from '@/utils/useMultiSelection'
+import { handleStageZoom, handleZoomScale } from '@/utils/zoom'
 
 export default function AnnotationViewer({
   id: containerId = uuidv4(),
@@ -103,7 +100,7 @@ export default function AnnotationViewer({
       handleZoomScale(
         stageObject.current,
         customZoomLevel,
-        imageBoundingBoxObject.current
+        imageBoundingBoxObject.current,
       )
     }
   }, [customZoomLevel])
@@ -136,7 +133,7 @@ export default function AnnotationViewer({
     getStage?.(stageObject.current)
     stageObject.current.add(
       layersObject.current.image,
-      layersObject.current.shapes
+      layersObject.current.shapes,
     )
     stageObject.current.on('wheel', onZoom)
     layersObject.current.image.add(imageDataObject.current.shape)
@@ -144,7 +141,7 @@ export default function AnnotationViewer({
       stageObject.current.on('mousemove', () => {
         const mousePointTo = getMousePosition(
           stageObject.current,
-          imageBoundingBoxObject.current
+          imageBoundingBoxObject.current,
         )
         mousePointTo && getPointerPosition(mousePointTo)
       })
@@ -155,21 +152,21 @@ export default function AnnotationViewer({
           event,
           layersObject.current.shapes,
           selectionRectObject.current,
-          isSelectionActiveRef.current
-        )
+          isSelectionActiveRef.current,
+        ),
       )
       stageObject.current.on('mousemove touchmove', () =>
         onSelectionMove(
           layersObject.current.shapes,
-          selectionRectObject.current
-        )
+          selectionRectObject.current,
+        ),
       )
       stageObject.current.on('mouseup touchend', () =>
         onSelectionEnd(
           layersObject.current.shapes,
           selectionRectObject.current,
-          onShapeMultiSelect
-        )
+          onShapeMultiSelect,
+        ),
       )
     }
   }
@@ -208,7 +205,7 @@ export default function AnnotationViewer({
       options,
       onShapeClick,
       onShapeMouseEnter,
-      onShapeMouseLeave
+      onShapeMouseLeave,
     )
     layersObject.current.shapes.batchDraw()
   }
@@ -217,7 +214,7 @@ export default function AnnotationViewer({
     const imageBoundingBox = handleResizeImage(
       stageObject.current,
       containerRef.current,
-      imageDataObject.current
+      imageDataObject.current,
     )
     if (imageBoundingBox) {
       imageBoundingBoxObject.current = imageBoundingBox
@@ -231,7 +228,7 @@ export default function AnnotationViewer({
       stageObject.current,
       imageBoundingBoxObject.current,
       event,
-      options
+      options,
     )
   }
   return (

--- a/src/components/dynamicZoom.spec.tsx
+++ b/src/components/dynamicZoom.spec.tsx
@@ -1,9 +1,10 @@
 import React, { useRef, useState } from 'react'
-
 import dummyImage from 'cypress/assets/demo.jpg'
 import { dummyShapes } from 'cypress/assets/shapes'
-import { PointerPosition } from '@/common/types'
 import { Stage } from 'konva/lib/Stage'
+
+import { PointerPosition } from '@/common/types'
+
 import AnnotationViewer from './AnnotationViewer'
 
 const containerHeight = 700
@@ -83,7 +84,7 @@ describe('AnnotationViewer', () => {
       <AnnotationViewerWithDynamicZoom
         id="annotationViewer"
         data={{ image: dummyImage, shapes: dummyShapes }}
-      />
+      />,
     )
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,25 @@
 import { Stage } from 'konva/lib/Stage'
-import {
-  AnnotationShape,
-  AnnotationLensOptions,
-  AnnotationViewerOptions,
-  PointerPosition,
-  Orientation,
-  AnnotationData,
-} from './common/types'
 
+import {
+  AnnotationData,
+  AnnotationLensOptions,
+  AnnotationShape,
+  AnnotationViewerOptions,
+  Orientation,
+  PointerPosition,
+} from './common/types'
+import AnnotationLens from './components/AnnotationLens'
+import AnnotationViewer from './components/AnnotationViewer'
 import {
   drawLayer,
   drawShape,
-  setShapeConfig,
   drawShapes,
+  setShapeConfig,
   toBase64,
 } from './utils/functions'
 import getImagesFromPDF from './utils/getImagesFromPDF'
-import AnnotationLens from './components/AnnotationLens'
-import AnnotationViewer from './components/AnnotationViewer'
 import { dataURItoBlob } from './utils/image'
+
 export type {
   Stage,
   AnnotationShape,

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,14 +1,15 @@
+import Konva from 'konva'
+import { Layer } from 'konva/lib/Layer'
+import { Line } from 'konva/lib/shapes/Line'
+
+import { KONVA_REFS } from '@/common/constants'
 import {
-  AnnotationShape,
   AnnotationLensOptions,
+  AnnotationShape,
   AnnotationViewerOptions,
   ImageBoundingBox,
   PointerPosition,
 } from '@/common/types'
-import { KONVA_REFS } from '@/common/constants'
-import Konva from 'konva'
-import { Layer } from 'konva/lib/Layer'
-import { Line } from 'konva/lib/shapes/Line'
 
 export const mapShapesToPolygons = (
   shapesLayer: Layer,
@@ -18,7 +19,7 @@ export const mapShapesToPolygons = (
   options: AnnotationLensOptions | AnnotationViewerOptions,
   onClick?: (shape: AnnotationShape) => void,
   onShapeMouseEnter?: (shape: AnnotationShape) => void,
-  onShapeMouseLeave?: (shape: AnnotationShape) => void
+  onShapeMouseLeave?: (shape: AnnotationShape) => void,
 ) => {
   if (!imageBoundingBox) {
     return
@@ -41,7 +42,7 @@ export const mapShapesToPolygons = (
         options as AnnotationViewerOptions,
         onClick,
         onShapeMouseEnter,
-        onShapeMouseLeave
+        onShapeMouseLeave,
       )
     }
   })
@@ -52,7 +53,7 @@ const bindEventToPolygon = (
   options: AnnotationViewerOptions,
   onClick?: (shape: AnnotationShape) => void,
   onShapeMouseEnter?: (shape: AnnotationShape) => void,
-  onShapeMouseLeave?: (shape: AnnotationShape) => void
+  onShapeMouseLeave?: (shape: AnnotationShape) => void,
 ) => {
   const stage = polygon.getStage()
   const shape = polygon.getAttr('shape')
@@ -77,7 +78,7 @@ const bindEventToPolygon = (
 
 export const scalePointToImage = (
   point: PointerPosition,
-  imageBoundingBox: ImageBoundingBox
+  imageBoundingBox: ImageBoundingBox,
 ) => {
   const { width, height, scale } = imageBoundingBox
   return {
@@ -88,12 +89,12 @@ export const scalePointToImage = (
 
 const mapCoordinatesToPoints = (
   coordinates: number[][],
-  imageBoundingBox: ImageBoundingBox
+  imageBoundingBox: ImageBoundingBox,
 ): number[] =>
   coordinates.reduce((accumulator, element) => {
     const { x, y } = scalePointToImage(
       { x: element[0], y: element[1] },
-      imageBoundingBox
+      imageBoundingBox,
     )
     accumulator = accumulator.concat([x, y])
     return accumulator
@@ -101,7 +102,7 @@ const mapCoordinatesToPoints = (
 
 export const getMousePosition = (
   stage: Konva.Stage | null,
-  imageBoundingBox: ImageBoundingBox | null
+  imageBoundingBox: ImageBoundingBox | null,
 ) => {
   if (!stage || !imageBoundingBox) {
     return

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -14,7 +14,7 @@ import {
 export const mapShapesToPolygons = (
   shapesLayer: Layer,
   shapes: AnnotationShape[] = [],
-  useEvents: boolean = true,
+  useEvents = true,
   imageBoundingBox: ImageBoundingBox | null,
   options: AnnotationLensOptions | AnnotationViewerOptions,
   onClick?: (shape: AnnotationShape) => void,

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -1,7 +1,9 @@
-import { KONVA_REFS } from '@/common/constants'
 import Konva from 'konva'
 import { Layer } from 'konva/lib/Layer'
 import { LineConfig } from 'konva/lib/shapes/Line'
+
+import { KONVA_REFS } from '@/common/constants'
+
 import { Stage } from '..'
 
 export const drawLayer = (stage: Konva.Stage) => {
@@ -16,7 +18,7 @@ export const drawLayer = (stage: Konva.Stage) => {
 export const drawShape = (
   stage: Konva.Stage,
   id: string | number,
-  config: LineConfig
+  config: LineConfig,
 ) => {
   const shape = stage.findOne(`#${id}`)
   if (shape) {
@@ -40,7 +42,7 @@ export const drawShapes = (stage: Stage, config: LineConfig) => {
 export const setShapeConfig = (
   stage: Konva.Stage,
   id: string | number,
-  config: LineConfig
+  config: LineConfig,
 ) => {
   const shape = stage.findOne(`#${id}`)
   if (shape) {
@@ -56,5 +58,5 @@ export const toBase64 = (
     | 'application/pdf'
     | 'image/jpeg'
     | 'image/png'
-    | 'image/svg+xml' = 'image/jpeg'
+    | 'image/svg+xml' = 'image/jpeg',
 ) => `data:${type};base64,${base64}`

--- a/src/utils/getImagesFromPDF.spec.tsx
+++ b/src/utils/getImagesFromPDF.spec.tsx
@@ -1,5 +1,6 @@
-import multiPage from 'cypress/assets/multi-page.pdf'
 import brokenPDF from 'cypress/assets/broken-pdf.pdf'
+import multiPage from 'cypress/assets/multi-page.pdf'
+
 import getImagesFromPDF from './getImagesFromPDF'
 
 describe('getImageFromPDF', () => {

--- a/src/utils/getImagesFromPDF.ts
+++ b/src/utils/getImagesFromPDF.ts
@@ -1,17 +1,18 @@
-import { PDF_RESOLUTION, MAX_PDF_SCALE } from '@/common/constants'
-import { GlobalWorkerOptions, version, getDocument } from 'pdfjs-dist'
+import { getDocument, GlobalWorkerOptions, version } from 'pdfjs-dist'
 import {
   PDFDocumentProxy,
   PDFPageProxy,
   RenderParameters,
 } from 'pdfjs-dist/types/display/api'
 
+import { MAX_PDF_SCALE, PDF_RESOLUTION } from '@/common/constants'
+
 GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${version}/pdf.worker.js`
 
 const getImageFromPage = (
   _document: PDFDocumentProxy,
   pageNumber: number,
-  resolution = PDF_RESOLUTION
+  resolution = PDF_RESOLUTION,
 ) =>
   new Promise<string>(async (resolve, reject) => {
     try {
@@ -45,7 +46,7 @@ export default function getImagesFromPDF(
   file: string,
   maxPages = Infinity,
   onSuccess?: () => void,
-  resolution?: number
+  resolution?: number,
 ) {
   return new Promise<string[]>((resolve, reject) => {
     getDocument(file)
@@ -59,8 +60,8 @@ export default function getImagesFromPDF(
         onSuccess?.()
         Promise.allSettled(
           Array.from(Array(document.numPages).keys()).map((index) =>
-            getImageFromPage(document, index + 1, resolution)
-          )
+            getImageFromPage(document, index + 1, resolution),
+          ),
         )
           .then((results) => {
             const images = results.reduce<string[]>((accumulator, result) => {

--- a/src/utils/getImagesFromPDF.ts
+++ b/src/utils/getImagesFromPDF.ts
@@ -9,38 +9,31 @@ import { MAX_PDF_SCALE, PDF_RESOLUTION } from '@/common/constants'
 
 GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${version}/pdf.worker.js`
 
-const getImageFromPage = (
+const getImageFromPage = async (
   _document: PDFDocumentProxy,
   pageNumber: number,
   resolution = PDF_RESOLUTION,
-) =>
-  new Promise<string>(async (resolve, reject) => {
-    try {
-      const page: PDFPageProxy = await _document.getPage(pageNumber)
-      const canvas = document.createElement('canvas')
-      const context = canvas.getContext('2d')
-      const [, , width, height] = page.view
-      const newScale = (resolution / (height * width)) ** (1 / 2)
-      const safeScale = Math.min(newScale, MAX_PDF_SCALE)
-      const viewport = page.getViewport({ scale: safeScale })
-      canvas.height = viewport.height
-      canvas.width = viewport.width
-      const renderContext = {
-        canvasContext: context,
-        viewport: viewport,
-      }
-      page
-        .render(renderContext as RenderParameters)
-        .promise.then(() => {
-          resolve(canvas.toDataURL())
-        })
-        .catch((error) => {
-          reject(error)
-        })
-    } catch (error) {
-      reject(error)
-    }
-  })
+) => {
+  const page: PDFPageProxy = await _document.getPage(pageNumber)
+  const canvas = document.createElement('canvas')
+  const context = canvas.getContext('2d')
+  const [, , width, height] = page.view
+  const newScale = (resolution / (height * width)) ** (1 / 2)
+  const safeScale = Math.min(newScale, MAX_PDF_SCALE)
+  const viewport = page.getViewport({ scale: safeScale })
+  canvas.height = viewport.height
+  canvas.width = viewport.width
+  const renderContext = {
+    canvasContext: context,
+    viewport: viewport,
+  }
+  return page
+    .render(renderContext as RenderParameters)
+    .promise.then(() => canvas.toDataURL())
+    .catch((error) => {
+      throw new Error(error)
+    })
+}
 
 export default function getImagesFromPDF(
   file: string,

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,7 +1,9 @@
-import { ImageBoundingBox, PointerPosition } from './../common/types'
-import { ImageData } from '@/common/types'
 import Konva from 'konva'
+
+import { ImageData } from '@/common/types'
+
 import { Stage } from '..'
+import { ImageBoundingBox, PointerPosition } from './../common/types'
 
 export const dataURItoBlob = (dataURI: string) => {
   let byteString
@@ -26,7 +28,7 @@ export const dataURItoBlob = (dataURI: string) => {
 
 export const computeImageBoundingBox = (
   { clientWidth, clientHeight }: HTMLDivElement,
-  imageObj: HTMLImageElement
+  imageObj: HTMLImageElement,
 ) => {
   const imageAspectRatio = imageObj.width / imageObj.height
   const canvasAspectRatio = clientWidth / clientHeight
@@ -62,7 +64,7 @@ const resizeStage = (stage: Konva.Stage, container: HTMLDivElement) => {
 export const handleResizeImage = (
   stage: Konva.Stage | null,
   container: HTMLDivElement | null,
-  { element, shape }: ImageData
+  { element, shape }: ImageData,
 ) => {
   if (!container || !stage) {
     return

--- a/src/utils/orientation.ts
+++ b/src/utils/orientation.ts
@@ -101,7 +101,7 @@ const applyRotation = (file: string, orientation: number) =>
         0,
         0,
         outputCanvas.width,
-        outputCanvas.height
+        outputCanvas.height,
       )
 
       // export image data

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -1,12 +1,12 @@
-import { KONVA_REFS } from '@/common/constants'
 import Konva from 'konva'
-
-import { AnnotationShape, AnnotationViewerOptions } from '@/common/types'
 import { Layer } from 'konva/lib/Layer'
 import { KonvaEventObject } from 'konva/lib/Node'
+import { Line } from 'konva/lib/shapes/Line'
 import { Rect } from 'konva/lib/shapes/Rect'
 import { Stage } from 'konva/lib/Stage'
-import { Line } from 'konva/lib/shapes/Line'
+
+import { KONVA_REFS } from '@/common/constants'
+import { AnnotationShape, AnnotationViewerOptions } from '@/common/types'
 
 export const createSelectionRect = (options: AnnotationViewerOptions) =>
   new Konva.Rect({
@@ -18,7 +18,7 @@ export const onSelectionStart = (
   event?: KonvaEventObject<Stage>,
   layer?: Layer,
   rect?: Rect,
-  selectionEnabled?: boolean
+  selectionEnabled?: boolean,
 ) => {
   if (!selectionEnabled || !layer || !rect || !event) {
     return
@@ -69,7 +69,7 @@ export const onSelectionMove = (layer?: Layer, rect?: Rect) => {
 export const onSelectionEnd = (
   layer?: Layer,
   rect?: Rect,
-  onShapeMultiSelect?: (shapes: AnnotationShape[]) => void
+  onShapeMultiSelect?: (shapes: AnnotationShape[]) => void,
 ) => {
   // no nothing if we didn't start selection
   const stage = layer?.getStage()
@@ -86,7 +86,7 @@ export const onSelectionEnd = (
   const box = rect.getClientRect()
   const selected = shapes
     .filter((shape: Konva.Shape) =>
-      Konva.Util.haveIntersection(box, shape.getClientRect())
+      Konva.Util.haveIntersection(box, shape.getClientRect()),
     )
     .map((shape: Konva.Shape) => shape.getAttr('shape'))
   if (selected.length) {

--- a/src/utils/useEventListener.ts
+++ b/src/utils/useEventListener.ts
@@ -1,14 +1,14 @@
-import { useRef, useEffect, RefObject } from 'react'
+import { RefObject, useEffect, useRef } from 'react'
 
 export default function useEventListener<
   T extends HTMLElement = HTMLDivElement,
-  E = Event
+  E = Event,
 >(
   eventName: string,
 
   handler: (event: E) => void,
 
-  element?: RefObject<T>
+  element?: RefObject<T>,
 ) {
   // Create a ref that stores handler
 

--- a/src/utils/useEventListener.ts
+++ b/src/utils/useEventListener.ts
@@ -34,7 +34,7 @@ export default function useEventListener<
     const eventListener = (event: E) => {
       // eslint-disable-next-line no-extra-boolean-cast
 
-      if (!!savedHandler?.current) {
+      if (savedHandler?.current) {
         savedHandler.current(event)
       }
     }

--- a/src/utils/useMultiSelection.ts
+++ b/src/utils/useMultiSelection.ts
@@ -1,6 +1,7 @@
-import useEventListener from './useEventListener'
 import { MutableRefObject } from 'react'
 import Konva from 'konva'
+
+import useEventListener from './useEventListener'
 
 interface Props {
   stage: Konva.Stage | null
@@ -23,7 +24,7 @@ export default function useMultiSelection({
         stage?.draggable(false)
         isSelectionActiveRef.current = true
       }
-    }
+    },
   )
   useEventListener<HTMLDivElement, KeyboardEvent>(
     'keyup',
@@ -38,6 +39,6 @@ export default function useMultiSelection({
         stage?.draggable(true)
         isSelectionActiveRef.current = false
       }
-    }
+    },
   )
 }

--- a/src/utils/zoom.ts
+++ b/src/utils/zoom.ts
@@ -1,17 +1,19 @@
-import { ZoomOptions } from './../common/types'
+import Konva from 'konva'
+import { KonvaEventObject } from 'konva/lib/Node'
+
 import { DEFAULT_LENS_ZOOM_LEVEL } from '@/common/constants'
 import {
   AnnotationViewerOptions,
   ImageBoundingBox,
   PointerPosition,
 } from '@/common/types'
-import Konva from 'konva'
-import { KonvaEventObject } from 'konva/lib/Node'
+
+import { ZoomOptions } from './../common/types'
 
 export const handleZoomScale = (
   stage: Konva.Stage | null,
   zoomScale: number,
-  imageBoundingBox: ImageBoundingBox | null
+  imageBoundingBox: ImageBoundingBox | null,
 ) => {
   if (!stage || !imageBoundingBox) {
     return
@@ -51,7 +53,7 @@ export const handleStageZoom = (
   stage: Konva.Stage | null,
   imageBoundingBox: ImageBoundingBox | null,
   event: KonvaEventObject<any>,
-  options: AnnotationViewerOptions
+  options: AnnotationViewerOptions,
 ) => {
   if (!stage || !imageBoundingBox) {
     return
@@ -100,7 +102,7 @@ export const handleLensZoom = (
   stage: Konva.Stage | null,
   imageBoundingBox: ImageBoundingBox | null,
   pointerPosition: PointerPosition,
-  zoomLevel = DEFAULT_LENS_ZOOM_LEVEL
+  zoomLevel = DEFAULT_LENS_ZOOM_LEVEL,
 ) => {
   if (!stage || !imageBoundingBox) {
     return

--- a/src/utils/zoom.ts
+++ b/src/utils/zoom.ts
@@ -8,8 +8,6 @@ import {
   PointerPosition,
 } from '@/common/types'
 
-import { ZoomOptions } from './../common/types'
-
 export const handleZoomScale = (
   stage: Konva.Stage | null,
   zoomScale: number,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "paths": {
       "@/*": ["src/*"],
       "cypress/*": ["./cypress/*"]
-    }
+    },
+    "skipLibCheck": true
   },
   "include": ["src", "cypress"],
   "exclude": ["node_modules", "dist", "docs"]


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Update prettier configuration with sorting import plugin and other rules we have in other Mindee applications
Update eslint configuration to match other Mindee applications
Fix lint error caused by having an async promise executor function in `getImageFromPage` util function
Some scripts have been added to **package.json**: `prettier:check`, `prettier:write` and `lint`

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Updates to prettier and eslint configuration aim to improve code quality moving forward and help to improve consistency across every frontend project at Mindee

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executed and monitored lint scripts

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [ ] All new and existing tests passed.
